### PR TITLE
sawyer/refactor/image ui cleanup

### DIFF
--- a/apps/onagal/lib/onagal/images.ex
+++ b/apps/onagal/lib/onagal/images.ex
@@ -75,6 +75,10 @@ defmodule Onagal.Images do
     Image.changeset(image, attrs)
   end
 
+  def ui_change_image(%Image{} = image, attrs \\ %{}) do
+    Image.ui_edit_changeset(image, attrs)
+  end
+
   def update_image(%Image{} = image, attrs) do
     image
     |> Image.changeset(attrs)

--- a/apps/onagal/lib/onagal/images/image.ex
+++ b/apps/onagal/lib/onagal/images/image.ex
@@ -19,6 +19,7 @@ defmodule Onagal.Images.Image do
 
   @required_fields ~w(current_name original_name location)a
   @optional_fields ~w(digest size file_type)a
+  @ui_edit_fields ~w(original_name)a
   # @allowed_file_types
 
   def changeset(record, params \\ :empty) do
@@ -27,5 +28,11 @@ defmodule Onagal.Images.Image do
     |> unique_constraint([:current_name, :location])
     |> unique_constraint([:size, :digest])
     |> validate_required(@required_fields)
+  end
+
+  def ui_edit_changeset(record, params \\ :empty) do
+    record
+    |> cast(params, @ui_edit_fields)
+    |> validate_required(@ui_edit_fields)
   end
 end

--- a/apps/onagal_fs/lib/onagal/fs.ex
+++ b/apps/onagal_fs/lib/onagal/fs.ex
@@ -54,7 +54,7 @@ defmodule Onagal.Fs do
   def cleanup_file(fpath) when is_binary(fpath) do
     IO.puts("handling file removed event for #{fpath}")
 
-    with {:ok, _} <- Onagal.Fs.Persist.remove_files_info([{fpath, nil}]),
+    with {:ok, _} <- Onagal.Fs.Persist.remove_files_info([{fpath, nil, nil}]),
          {:ok, _} <- Onagal.Fs.Manage.remove_managed_file(fpath) do
       IO.puts("file #{fpath} removed")
       {:ok, :file_removed}
@@ -71,7 +71,7 @@ defmodule Onagal.Fs do
     with true <- Onagal.Fs.Persist.is_image?(fpath),
          {:ok, fstat} <- File.stat(fpath),
          {:ok, new_path} <- Onagal.Fs.Manage.migrate_managed_file(fpath),
-         {:ok, _} <- Onagal.Fs.Persist.persist_files_info([{new_path, fstat}]) do
+         {:ok, _} <- Onagal.Fs.Persist.persist_files_info([{new_path, fpath, fstat}]) do
       IO.puts("file_added(#{fpath}) / #{new_path}")
       {:ok, :file_added}
     else

--- a/apps/onagal_fs/lib/onagal/fs/persist.ex
+++ b/apps/onagal_fs/lib/onagal/fs/persist.ex
@@ -56,7 +56,7 @@ defmodule Onagal.Fs.Persist do
   def filter_non_images(file_list) when is_list(file_list) do
     image_files =
       file_list
-      |> Enum.filter(fn {fpath, _} -> is_image?(fpath) end)
+      |> Enum.filter(fn {fpath, _, _} -> is_image?(fpath) end)
 
     image_files
   end
@@ -73,12 +73,13 @@ defmodule Onagal.Fs.Persist do
 
   def is_image?(_), do: false
 
-  defp persist_file_info({path, file_stat} = fileinfo) when is_tuple(fileinfo) do
+  defp persist_file_info({path, old_path, file_stat} = fileinfo) when is_tuple(fileinfo) do
     fpath = Path.dirname(path)
     file = String.downcase(Path.basename(path))
+    old_name = Path.basename(old_path)
 
     image_data = %{
-      original_name: file,
+      original_name: old_name,
       current_name: file,
       location: fpath,
       size: file_stat.size,
@@ -94,7 +95,7 @@ defmodule Onagal.Fs.Persist do
 
   defp persist_file_info(_), do: {:error, :invalid_file_data}
 
-  defp remove_file_info({path, _} = fileinfo) when is_tuple(fileinfo) do
+  defp remove_file_info({path, _, _} = fileinfo) when is_tuple(fileinfo) do
     fpath = Path.dirname(path)
     file = String.downcase(Path.basename(path))
 

--- a/apps/onagal_web/.gitignore
+++ b/apps/onagal_web/.gitignore
@@ -33,3 +33,5 @@ npm-debug.log
 /assets/node_modules/
 
 /priv/cert/
+
+/tmp/

--- a/apps/onagal_web/lib/onagal_web/live/image_live/form_component.ex
+++ b/apps/onagal_web/lib/onagal_web/live/image_live/form_component.ex
@@ -17,7 +17,7 @@ defmodule OnagalWeb.ImageLive.FormComponent do
   def handle_event("validate", %{"image" => image_params}, socket) do
     changeset =
       socket.assigns.image
-      |> Images.change_image(image_params)
+      |> Images.ui_change_image(image_params)
       |> Map.put(:action, :validate)
 
     {:noreply, assign(socket, :changeset, changeset)}

--- a/apps/onagal_web/lib/onagal_web/live/image_live/index.ex
+++ b/apps/onagal_web/lib/onagal_web/live/image_live/index.ex
@@ -20,11 +20,11 @@ defmodule OnagalWeb.ImageLive.Index do
     |> assign(:image, Images.get_image!(id))
   end
 
-  defp apply_action(socket, :new, _params) do
-    socket
-    |> assign(:page_title, "New Image")
-    |> assign(:image, %Image{})
-  end
+  # defp apply_action(socket, :new, _params) do
+  #   socket
+  #   |> assign(:page_title, "New Image")
+  #   |> assign(:image, %Image{})
+  # end
 
   defp apply_action(socket, :index, _params) do
     socket

--- a/apps/onagal_web/lib/onagal_web/live/image_live/index.html.heex
+++ b/apps/onagal_web/lib/onagal_web/live/image_live/index.html.heex
@@ -16,29 +16,27 @@
 <table>
   <thead>
     <tr>
-      <th style="max-width: 150px; word-wrap: break-all; overflow: hidden;">Current Name</th>
-      <th style="max-width: 150px; word-wrap: break-all;">Original Name</th>
-      <th style="max-width: 150px; word-wrap: break-all;">Location</th>
-      <th style="max-width: 150px; word-wrap: break-all;">Size</th>
-      <th style="max-width: 150px; word-wrap: break-all;">Digest</th>
-      <th style="max-width: 150px; word-wrap: break-all;">File Type</th>
-      <th style="max-width: 150px; word-wrap: break-all;">Inserted At</th>
-      <th style="max-width: 150px; word-wrap: break-all;">Updated At</th>
-      <th style="max-width: 150px; word-wrap: break-all;">Preview</th>
+      <th>Preview</th>
+      <th>Original Name</th>
+      <th>Size</th>
+      <th>Digest</th>
+      <th>File Type</th>
+      <th>Inserted At</th>
+      <th>Updated At</th>
     </tr>
   </thead>
   <tbody id="images">
     <%= for image <- @images do %>
       <tr id={"image-#{image.id}"}>
-        <td style="max-width: 150px; word-wrap: break-all; overflow: hidden;"><%= image.current_name %></td>
+        <td><%= live_redirect to: Routes.image_show_path(@socket, :show, image) do %>
+          <img src={resolve_thumbnail_path(image)}>
+        <% end %></td>
         <td style="max-width: 150px; word-wrap: break-all; overflow: hidden;"><%= image.original_name %></td>
-        <td style="max-width: 150px; word-wrap: break-all; overflow: hidden;"><%= image.location %></td>
         <td style="max-width: 150px; word-wrap: break-all; overflow: hidden;"><%= image.size %></td>
         <td style="max-width: 150px; word-wrap: break-all; overflow: hidden;"><%= image.digest %></td>
         <td style="max-width: 150px; word-wrap: break-all; overflow: hidden;"><%= image.file_type %></td>
         <td style="max-width: 150px; word-wrap: break-all; overflow: hidden;"><%= image.inserted_at %></td>
         <td style="max-width: 150px; word-wrap: break-all; overflow: hidden;"><%= image.updated_at %></td>
-        <td><img src={resolve_thumbnail_path(image)}></td>
 
         <td>
           <span><%= live_redirect "Show", to: Routes.image_show_path(@socket, :show, image) %></span>
@@ -49,5 +47,3 @@
     <% end %>
   </tbody>
 </table>
-
-<span><%= live_patch "New Image", to: Routes.image_index_path(@socket, :new) %></span>

--- a/apps/onagal_web/lib/onagal_web/router.ex
+++ b/apps/onagal_web/lib/onagal_web/router.ex
@@ -94,7 +94,7 @@ defmodule OnagalWeb.Router do
     pipe_through([:browser, :require_authenticated_user])
 
     live("/", ImageLive.Index, :index)
-    live("/new", ImageLive.Index, :new)
+    # live("/new", ImageLive.Index, :new)
     live("/:id/edit", ImageLive.Index, :edit)
 
     live("/:id", ImageLive.Show, :show)

--- a/apps/onagal_web/lib/onagal_web/templates/layout/root.html.heex
+++ b/apps/onagal_web/lib/onagal_web/templates/layout/root.html.heex
@@ -11,10 +11,20 @@
   </head>
   <body>
     <header>
-      <nav>
-        <%= render "_user_menu.html", assigns %>
-      </nav>
+      <section class="container">
+        <nav>
+          <%= render "_user_menu.html", assigns %>
+        </nav>
+      </section>
     </header>
+    <section class="container">
+      <ul>
+        <li><%= link "Images", to: Routes.image_index_path(@conn, :index) %></li>
+        <li><%= link "Tags", to: Routes.tag_index_path(@conn, :index) %></li>
+        <li><%= link "Tagsets", to: Routes.tagset_index_path(@conn, :index) %></li>
+        <li><%= link "Galleries", to: Routes.gallery_index_path(@conn, :index) %></li>
+      </ul>
+    </section>
     <%= @inner_content %>
   </body>
 </html>

--- a/apps/onagal_web/mix.exs
+++ b/apps/onagal_web/mix.exs
@@ -49,7 +49,7 @@ defmodule OnagalWeb.MixProject do
       {:telemetry_poller, "~> 1.0"},
       {:gettext, "~> 0.18"},
       {:onagal, in_umbrella: true},
-      {:onagal, in_umbrella: true},
+      {:onagal_fs, in_umbrella: true},
       {:jason, "~> 1.2"},
       {:plug_cowboy, "~> 2.5"}
     ]


### PR DESCRIPTION
- changed image edit form to use edit-only changeset to match form restrictions.
- updated onagal_fs file add call flows to incorporate original and current file names (fixes bad data in DB - current and original names were both current).
- removed image "new" action in router and ui (you cannot create images that way)
- added simplistic "nav" options to main ui (until better nav is in place). also fixed umbrella deps.
