### PR TITLE
sawyer/cleanup/cleanup fix inter page pagination

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "mix_task",
+            "name": "mix (Default task)",
+            "request": "launch",
+            "projectDir": "${workspaceRoot}"
+        },
+        {
+            "type": "mix_task",
+            "name": "mix test",
+            "request": "launch",
+            "task": "test",
+            "taskArgs": [
+                "--trace"
+            ],
+            "startApps": true,
+            "projectDir": "${workspaceRoot}",
+            "requireFiles": [
+                "test/**/test_helper.exs",
+                "test/**/*_test.exs"
+            ]
+        }
+    ]
+}

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,10 @@
 
 - Refactoring pass on onagal_fs, its a rats nest in there
 - Possible refactor with onagal.images as well
+- massive refactor needed in live/index
 X Figure out how to pass filter state between image :index and :show
-- handle inter-page paging (paging boundaries just loop the page currently)
-- handle case where changing to an empty pageset while in :show breaks everything
+X handle inter-page paging (paging boundaries just loop the page currently)
+X handle case where changing to an empty pageset while in :show breaks everything
+- empty page set in show should knock user back to gallery view 
+- switching filters in show works but displays the wrong image relative to the :id
+- reloading in show can either infinite loop (??) or crash....

--- a/apps/onagal/lib/onagal/images.ex
+++ b/apps/onagal/lib/onagal/images.ex
@@ -116,10 +116,12 @@ defmodule Onagal.Images do
         []
 
       _ ->
+        prev_index = if index == 0, do: index, else: index - 1
+
         [
-          Enum.at(page.entries, index - 1) || tl(page.entries),
+          Enum.at(page.entries, prev_index),
           image,
-          Enum.at(page.entries, index + 1) || hd(page.entries)
+          Enum.at(page.entries, index + 1)
         ]
     end
   end

--- a/apps/onagal_web/lib/onagal_web/live/gallery_live/display_component.ex
+++ b/apps/onagal_web/lib/onagal_web/live/gallery_live/display_component.ex
@@ -8,7 +8,8 @@ defmodule OnagalWeb.GalleryLive.DisplayComponent do
           id: "display",
           prev_image: prev_image,
           next_image: next_image,
-          image_path: image_path
+          image_path: image_path,
+          image_id: image_id
         } = _assigns,
         socket
       ) do
@@ -19,6 +20,7 @@ defmodule OnagalWeb.GalleryLive.DisplayComponent do
       |> assign(:prev_image, prev_image)
       |> assign(:next_image, next_image)
       |> assign(:image_path, image_path)
+      |> assign(:image_id, image_id)
 
     {:ok, socket}
   end
@@ -29,9 +31,13 @@ defmodule OnagalWeb.GalleryLive.DisplayComponent do
     ~H"""
     <ul>
       <span><%= live_patch "Back", to: Routes.gallery_index_path(@socket, :index) %></span>
-      <span><%= live_patch "Prev", to: Routes.gallery_index_path(@socket, :show, @prev_image.id) %></span>
+      <%= if @prev_image.id != @image_id do %>
+        <span><%= live_patch "Prev", to: Routes.gallery_index_path(@socket, :show, @prev_image.id) %></span>
+      <% end %>
       <img src={@image_path}>
-      <span><%= live_patch "Next", to: Routes.gallery_index_path(@socket, :show, @next_image.id) %></span>
+      <%= if @next_image.id != @image_id do %>
+        <span><%= live_patch "Next", to: Routes.gallery_index_path(@socket, :show, @next_image.id) %></span>
+      <% end %>
     </ul>
     """
   end

--- a/apps/onagal_web/lib/onagal_web/live/gallery_live/index.html.heex
+++ b/apps/onagal_web/lib/onagal_web/live/gallery_live/index.html.heex
@@ -4,9 +4,9 @@
   </div>
   <div class="flex-child" style="flex: 1; height: 720px;">
     <%= if @live_action == :index do %>
-      <.live_component module={OnagalWeb.GalleryLive.MontageComponent} id="montage" page={@page} />
+      <.live_component module={OnagalWeb.GalleryLive.MontageComponent} id="montage" images={@images} />
     <% else %>
-      <.live_component module={OnagalWeb.GalleryLive.DisplayComponent} id="display" prev_image={@prev_image} next_image={@next_image} image_path={@image_path}/>
+      <.live_component module={OnagalWeb.GalleryLive.DisplayComponent} id="display" image_id={@image_id} prev_image={@prev_image} next_image={@next_image} image_path={@image_path}/>
     <% end %>
   </div>
 </div>

--- a/apps/onagal_web/lib/onagal_web/live/gallery_live/montage_component.ex
+++ b/apps/onagal_web/lib/onagal_web/live/gallery_live/montage_component.ex
@@ -4,12 +4,12 @@ defmodule OnagalWeb.GalleryLive.MontageComponent do
   alias Onagal.Images
 
   def update(
-        %{id: "montage", page: page} = _assigns,
+        %{id: "montage", images: images} = _assigns,
         socket
       ) do
     socket =
       socket
-      |> assign(:page, page)
+      |> assign(:images, images)
 
     {:ok, socket}
   end
@@ -18,7 +18,7 @@ defmodule OnagalWeb.GalleryLive.MontageComponent do
     ~H"""
     <div>
       <ul class="imglist">
-        <%= for image <- @page.entries do %>
+        <%= for image <- @images.entries do %>
           <li>
             <%= live_patch to: Routes.gallery_index_path(@socket, :show, image) do %>
               <img src={Images.resolve_thumbnail_path(image)} alt={image.original_name}>
@@ -28,15 +28,15 @@ defmodule OnagalWeb.GalleryLive.MontageComponent do
       </ul>
 
       <div class="pagination">
-        <%= if @page.page_number > 1 do %>
+        <%= if @images.page_number > 1 do %>
           <%= live_patch "<< Prev Page",
-              to: Routes.gallery_index_path(@socket, :index, page: @page.page_number - 1),
+              to: Routes.gallery_index_path(@socket, :index, page: @images.page_number - 1),
               class: "pagination-link" %>
         <% end %>
 
-        <%= if @page.page_number < @page.total_pages do %>
+        <%= if @images.page_number < @images.total_pages do %>
           <%= live_patch "Next Page >>",
-              to: Routes.gallery_index_path(@socket, :index, page: @page.page_number + 1),
+              to: Routes.gallery_index_path(@socket, :index, page: @images.page_number + 1),
               class: "pagination-link" %>
         <% end %>
       </div>


### PR DESCRIPTION
- fixed paging bug where 0-index (first) image would "wrap around" due to -1 for Enum.at
- Fixed broken pagination (mostly). Incoming show page id is validated against current page, and nav links updated as necessary.
