### PR TITLE
sawyer/refactor/unify refactor cleanup subpagination in gallerylive

### DIFF
--- a/apps/onagal/lib/onagal/images.ex
+++ b/apps/onagal/lib/onagal/images.ex
@@ -61,17 +61,6 @@ defmodule Onagal.Images do
 
   def get_first(), do: Image |> first() |> Repo.one()
 
-  # @spec get_prev_image(integer, map) :: any
-  # def get_prev_image(id, []) do
-  #   query =
-  #     from i in Image,
-  #       where: i.id < ^id,
-  #       order_by: [desc: i.id],
-  #       limit: 1
-
-  #   Repo.one(query) || get_last_image()
-  # end
-
   @doc """
     FIX: This needs to be refactored to share query basics with the normal index image tag
     fiter. Yes this does not handle wrap arounds.
@@ -92,17 +81,6 @@ defmodule Onagal.Images do
     Repo.one(query) || get_last_image()
   end
 
-  # def get_next_image(id, []) do
-  #   query =
-  #     from i in Image,
-  #       where: i.id > ^id,
-  #       preload: [:tags],
-  #       order_by: i.id,
-  #       limit: 1
-
-  #   Repo.one(query) || get_first_image()
-  # end
-
   @doc """
     FIX: This needs to be refactored to share query basics with the normal index image tag
     fiter. Yes this does not handle wrap arounds.
@@ -121,40 +99,6 @@ defmodule Onagal.Images do
       )
 
     Repo.one(query) || get_first_image()
-  end
-
-  def find_page_tuple(page, image) do
-    IO.puts("find_page_tuple")
-
-    case index = Enum.find_index(page.entries, fn img -> img.id == image.id end) do
-      nil ->
-        []
-
-      _ ->
-        prev_index = if index == 0, do: index, else: index - 1
-
-        [
-          Enum.at(page.entries, prev_index),
-          image,
-          Enum.at(page.entries, index + 1)
-        ]
-    end
-  end
-
-  def next_image_on_page(page, image) do
-    case find_page_tuple(page, image) do
-      [] -> get_first()
-      [_, _, next_image] -> next_image
-    end
-  end
-
-  def prev_image_on_page(page, image) do
-    IO.puts("images prev_image_on_page")
-
-    case find_page_tuple(page, image) do
-      [] -> get_first()
-      [prev_image, _, _] -> prev_image
-    end
   end
 
   def get_first_image() do
@@ -329,7 +273,6 @@ defmodule Onagal.Images do
         group_by: image.id
       )
 
-    IO.inspect(params)
     Repo.paginate(query, params)
   end
 

--- a/apps/onagal_web/lib/onagal_web/live/gallery_live/display_component.ex
+++ b/apps/onagal_web/lib/onagal_web/live/gallery_live/display_component.ex
@@ -9,8 +9,7 @@ defmodule OnagalWeb.GalleryLive.DisplayComponent do
           prev_image: prev_image,
           next_image: next_image,
           image_path: image_path,
-          image_id: image_id,
-          itags: itags
+          image: image
         } = _assigns,
         socket
       ) do
@@ -19,14 +18,13 @@ defmodule OnagalWeb.GalleryLive.DisplayComponent do
       |> assign(:prev_image, prev_image)
       |> assign(:next_image, next_image)
       |> assign(:image_path, image_path)
-      |> assign(:itags, itags)
-      |> assign(:image_id, image_id)
+      |> assign(:image, image)
 
     {:ok, socket}
   end
 
-  def update(%{id: "display", itags: itags} = _assigns, socket) do
-    {:ok, socket |> assign(:itags, itags)}
+  def update(%{id: "display", image: image} = _assigns, socket) do
+    {:ok, socket |> assign(:image, image)}
   end
 
   def render(assigns) do
@@ -36,12 +34,12 @@ defmodule OnagalWeb.GalleryLive.DisplayComponent do
     <ul>
       <table>
         <tr>
-          <%= if @prev_image.id != @image_id do %>
+          <%= if @prev_image.id != @image.id do %>
             <td><%= live_patch "Prev", to: Routes.gallery_index_path(@socket, :show, @prev_image.id) %></td>
           <% else %>
             <td>Prev</td>
           <% end %>
-          <%= if @next_image.id != @image_id do %>
+          <%= if @next_image.id != @image.id do %>
             <td><%= live_patch "Next", to: Routes.gallery_index_path(@socket, :show, @next_image.id) %></td>
           <% else %>
             <td>Next</td>
@@ -55,12 +53,16 @@ defmodule OnagalWeb.GalleryLive.DisplayComponent do
       </div>
       <div>
         <ul class="imglist">
-        <%= for image_tag <- @itags do %>
+        <%= for image_tag <- list_tags_as_options(@image.tags) do %>
           <li><%= image_tag %></li>
         <% end %>
         </ul>
       </div>
     </ul>
     """
+  end
+
+  def list_tags_as_options(image_tags) do
+    Enum.map(image_tags, fn tag -> tag.name end)
   end
 end

--- a/apps/onagal_web/lib/onagal_web/live/gallery_live/filter_component.ex
+++ b/apps/onagal_web/lib/onagal_web/live/gallery_live/filter_component.ex
@@ -5,16 +5,19 @@ defmodule OnagalWeb.GalleryLive.FilterComponent do
 
   @impl true
   def update(
-        %{id: "filter", tag_filter: tag_filter, tag_list: tag_list, image_tags: image_tags} =
-          _assigns,
+        %{
+          id: "filter",
+          tag_list: tag_list,
+          selected_filters: selected_filters,
+          selected_tags: selected_tags
+        } = _assigns,
         socket
-      )
-      when is_list(tag_list) do
+      ) do
     socket =
       socket
-      |> assign(:tag_filter, tag_filter)
+      |> assign(:selected_filters, selected_filters)
+      |> assign(:selected_tags, selected_tags)
       |> assign(:tag_list, tag_list)
-      |> assign(:image_tags, image_tags)
       |> assign(:tagset_list, list_tagsets())
       |> assign(:filterset_list, list_filtersets())
 
@@ -23,7 +26,7 @@ defmodule OnagalWeb.GalleryLive.FilterComponent do
 
   # Filtering here
   @impl true
-  def handle_event("filter", %{"tag_filter" => %{"tags" => tags}} = params, socket) do
+  def handle_event("filter", %{"selected_filters" => %{"tags" => tags}} = params, socket) do
     IO.puts("filter_form handle_event filter 1")
 
     {:noreply, handle_filter_event(params, socket, tags)}
@@ -61,14 +64,14 @@ defmodule OnagalWeb.GalleryLive.FilterComponent do
     tags = Tags.list_tags_by_tagset_name(tagset)
 
     # {:noreply, handle_tag_event(params, socket, list_tags(tags), :replace)}
-    {:noreply, socket |> assign(:image_tags, list_tags(tags))}
+    {:noreply, socket |> assign(:selected_tags, list_tags(tags))}
   end
 
   # Tagging here
   @impl true
   def handle_event(
         "tag",
-        %{"tag_image" => %{"tags" => tags, "add_replace" => add_replace}} = params,
+        %{"selected_tags" => %{"tags" => tags, "add_replace" => add_replace}} = params,
         socket
       ) do
     IO.puts("filter_form handle_event tag 1")
@@ -78,7 +81,7 @@ defmodule OnagalWeb.GalleryLive.FilterComponent do
   end
 
   @impl true
-  def handle_event("tag", %{"tag_image" => %{"add_replace" => add_replace}} = params, socket) do
+  def handle_event("tag", %{"selected_tags" => %{"add_replace" => add_replace}} = params, socket) do
     IO.puts("filter_form handle_event tag 2")
     tags = []
     mode = if add_replace == "true", do: :replace, else: :add
@@ -90,18 +93,18 @@ defmodule OnagalWeb.GalleryLive.FilterComponent do
   defp handle_filter_event(params, socket, tags) do
     IO.puts("filter_form handle_filter_event")
 
-    send(self(), {:tag_filter, tags: tags, params: params})
+    send(self(), {:selected_filters, tags: tags, params: params})
 
-    socket |> assign(:tag_filter, tags)
+    socket |> assign(:selected_filters, tags)
   end
 
   # Tag helper
   defp handle_tag_event(params, socket, tags, mode) do
     IO.puts("filter_form handle_tag_event")
 
-    send(self(), {:tag_images, tags: tags, mode: mode, params: params})
+    send(self(), {:selected_tags, tags: tags, mode: mode, params: params})
 
-    socket |> assign(:tag_image, tags)
+    socket |> assign(:selected_tags, tags)
   end
 
   defp list_tags(tags) do

--- a/apps/onagal_web/lib/onagal_web/live/gallery_live/filter_component.html.heex
+++ b/apps/onagal_web/lib/onagal_web/live/gallery_live/filter_component.html.heex
@@ -10,12 +10,12 @@
     <hr/>
 
     <.form let={f}
-        for={:tag_filter}
+        for={:selected_filters}
         phx-submit="filter"
         phx-target={@myself}
     >
         <%= label f, :tags %>
-        <%= multiple_select f, :tags, @tag_list, selected: @tag_filter %>
+        <%= multiple_select f, :tags, @tag_list, selected: @selected_filters %>
 
         <%= label f, :reset %>
         <%= reset "Reset" %>
@@ -36,12 +36,12 @@
     <hr/>
 
     <.form let={f}
-        for={:tag_image}
+        for={:selected_tags}
         phx-submit="tag"
         phx-target={@myself}
         >
         <%= label f, :tags %>
-        <%= multiple_select f, :tags, @tag_list, selected: @image_tags %>
+        <%= multiple_select f, :tags, @tag_list, selected: @selected_tags %>
 
         <%= label f, :replace %>
         <%= checkbox f, :add_replace %>

--- a/apps/onagal_web/lib/onagal_web/live/gallery_live/index.html.heex
+++ b/apps/onagal_web/lib/onagal_web/live/gallery_live/index.html.heex
@@ -1,13 +1,13 @@
 <div class="flex-container" style="display: flex; align-items: stretch;">
     <div class="flex-child" style="flex: 0 1 240px; background: #03a9f4;">
-      <.live_component module={OnagalWeb.GalleryLive.FilterComponent} id="filter" tag_list={@tag_list} tag_filter={@tag_filter} image_tags={@image_tags} />
+      <.live_component module={OnagalWeb.GalleryLive.FilterComponent} id="filter" tag_list={@tag_list} selected_filters={@selected_filters} selected_tags={@selected_tags}/>
     </div>
   <div class="flex-child" style="flex: 1; height: 720px;">
     <%= if @live_action == :index do %>
       <.live_component module={OnagalWeb.GalleryLive.MontageComponent} id="montage" images={@images} selected_images={@selected_images} />
     <% else %>
       <.live_component module={OnagalWeb.GalleryLive.DisplayComponent} id="display"
-        image_id={@image_id} prev_image={@prev_image} next_image={@next_image} image_path={@image_path} itags={@itags} />
+        prev_image={@prev_image} next_image={@next_image} image_path={@image_path} image={@image} />
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
- Refactor and move all sub-pagination into Paginate. Cleanups to images.
- Refactoring pass on index (for pagination). Cleanup, refactoring and naming improvements across all components as well.
