### PR TITLE
sawyer/feature/add clear tags filters buttons to filter form

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,13 +24,15 @@
 - ~~Figure out why the heck gallerylive/index uses two different methods of sub-pagination navigation!??!?~~
   - ~~send_filter_update({:show,....})~~
   - ~~apply_action(socket, :show....)~~
+- ~~add "clear selected tags" to filters/tags~~
 
 * [*FEATURES*]
+- clearing filters should also submit to actually clear
 
 * [*FIXES/CLEANUPS*]
+- Fix missing menu errors on main landing page
 - [PARTIAL] cleanup send_*_update functions in GalleryLive/index.ex
 - [PARTIAL] Possible refactor with onagal.images as well
-- add "clear selected tags" to filters/tags 
 - switching filters in show works but displays the wrong image relative to the :id
 - Refactoring pass on onagal_fs, its a rats nest in there
 

--- a/apps/onagal_web/lib/onagal_web/live/gallery_live/filter_component.ex
+++ b/apps/onagal_web/lib/onagal_web/live/gallery_live/filter_component.ex
@@ -24,6 +24,16 @@ defmodule OnagalWeb.GalleryLive.FilterComponent do
     {:ok, socket}
   end
 
+  def update(%{id: "filter", selected_filters: selected_filters}, socket) do
+    IO.puts("filter_component :update selected_filters")
+    {:ok, socket |> assign(:selected_filters, selected_filters)}
+  end
+
+  def update(%{id: "filter", selected_tags: selected_tags}, socket) do
+    IO.puts("filter_component :update selected_tags")
+    {:ok, socket |> assign(:selected_tags, selected_tags)}
+  end
+
   # Filtering here
   @impl true
   def handle_event("filter", %{"selected_filters" => %{"tags" => tags}} = params, socket) do

--- a/apps/onagal_web/lib/onagal_web/live/gallery_live/filter_component.html.heex
+++ b/apps/onagal_web/lib/onagal_web/live/gallery_live/filter_component.html.heex
@@ -33,6 +33,8 @@
         <%= select f, :select_filterset, @filterset_list, phx_change: "filterset_select" %>
     </.form>
 
+    <button type="button" phx-click="clear_filters" value="clear">Clear Filters</button>
+
     <hr/>
 
     <.form let={f}
@@ -61,4 +63,6 @@
         <%= label f, :tagset %>
         <%= select f, :select_tagset, @tagset_list, phx_change: "tagset_select" %>
     </.form>
+
+    <button type="button" phx-click="clear_tags" value="clear">Clear Tags</button>
 </div>

--- a/apps/onagal_web/lib/onagal_web/live/gallery_live/index.ex
+++ b/apps/onagal_web/lib/onagal_web/live/gallery_live/index.ex
@@ -40,26 +40,6 @@ defmodule OnagalWeb.GalleryLive.Index do
     {:noreply, apply_action(socket, socket.assigns.live_action, params)}
   end
 
-  @impl true
-  def handle_info({:selected_filters, [tags: tags, params: params]}, socket) do
-    IO.puts("index handle_info :selected_filters")
-
-    images = list_images(params, tags)
-
-    image =
-      if images.entries == [],
-        do: Images.get_first(),
-        else: hd(images.entries) |> Onagal.Repo.preload(:tags)
-
-    socket =
-      socket
-      |> assign(:selected_filters, tags)
-      |> assign(:images, images)
-      |> assign(:image, image)
-
-    {:noreply, socket}
-  end
-
   defp apply_action(socket, :index, params) do
     IO.puts("apply_action :index")
 
@@ -86,6 +66,26 @@ defmodule OnagalWeb.GalleryLive.Index do
   end
 
   @impl true
+  def handle_info({:selected_filters, [tags: tags, params: params]}, socket) do
+    IO.puts("index handle_info :selected_filters")
+
+    images = list_images(params, tags)
+
+    image =
+      if images.entries == [],
+        do: Images.get_first(),
+        else: hd(images.entries) |> Onagal.Repo.preload(:tags)
+
+    socket =
+      socket
+      |> assign(:selected_filters, tags)
+      |> assign(:images, images)
+      |> assign(:image, image)
+
+    {:noreply, socket}
+  end
+
+  @impl true
   def handle_info({:selected_tags, [tags: tags, mode: mode, params: _params]}, socket) do
     IO.puts("index handle_info :selected_tags")
 
@@ -99,6 +99,32 @@ defmodule OnagalWeb.GalleryLive.Index do
     IO.puts("index handle_event clear_selections")
 
     {:noreply, socket |> assign(:selected_images, [])}
+  end
+
+  @impl true
+  def handle_event("clear_filters", %{"value" => "clear"}, socket) do
+    IO.puts("index handle_event clear_filters")
+
+    send_update(
+      OnagalWeb.GalleryLive.FilterComponent,
+      id: "filter",
+      selected_filters: []
+    )
+
+    {:noreply, socket |> assign(:selected_filters, [])}
+  end
+
+  @impl true
+  def handle_event("clear_tags", %{"value" => "clear"}, socket) do
+    IO.puts("index handle_event clear_tags")
+
+    send_update(
+      OnagalWeb.GalleryLive.FilterComponent,
+      id: "filter",
+      selected_tags: []
+    )
+
+    {:noreply, socket |> assign(:selected_tags, [])}
   end
 
   @impl true

--- a/apps/onagal_web/lib/onagal_web/router.ex
+++ b/apps/onagal_web/lib/onagal_web/router.ex
@@ -20,7 +20,9 @@ defmodule OnagalWeb.Router do
   scope "/", OnagalWeb do
     pipe_through(:browser)
 
-    get("/", PageController, :index)
+    live_session :default, on_mount: OnagalWeb.RouteAssigns do
+      get("/", PageController, :index)
+    end
   end
 
   # Other scopes may use custom stacks.


### PR DESCRIPTION
- Small change to unbreak starting "/" page (behaves oddly, but at least it isn't broken now).
- Clearing tags selection now works. Clearing filter selection works but doesn't submit the clear (so half-step).
